### PR TITLE
Improve startup error messages

### DIFF
--- a/poc/backend/app/main.py
+++ b/poc/backend/app/main.py
@@ -1,4 +1,9 @@
-from fastapi import FastAPI, Depends
+try:
+    from fastapi import FastAPI, Depends
+except ImportError as exc:  # pragma: no cover - runtime dependency check
+    raise SystemExit(
+        "FastAPI is not installed. Run `pip install -r poc/backend/requirements.txt`"
+    ) from exc
 from .auth import router as auth_router, get_current_user
 from .video import router as video_router
 from .chat import router as chat_router

--- a/poc/frame-processor/app/main.py
+++ b/poc/frame-processor/app/main.py
@@ -1,5 +1,10 @@
 import time
-import yaml
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - runtime dependency check
+    raise SystemExit(
+        "PyYAML is not installed. Run `pip install -r poc/frame-processor/requirements.txt`"
+    ) from exc
 from .processor import FrameProcessor
 
 

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,23 @@ poc/
 
 The backend will expose `http://localhost:8000` and the frontend will be available on `http://localhost:3000`.
 
+### Running services without Docker
+
+If you want to execute the backend or frame processor directly with Python,
+install their requirements first:
+
+```bash
+pip install -r poc/backend/requirements.txt
+pip install -r poc/frame-processor/requirements.txt
+```
+
+After installing the packages you can start the services with:
+
+```bash
+python poc/backend/app/main.py
+python poc/frame-processor/app/main.py
+```
+
 ## Using the application
 
 - Obtain a token by sending a POST request to `/auth/login` with form fields `username` and `password` (default user is `admin`/`admin123`).


### PR DESCRIPTION
## Summary
- handle ImportError in backend and frame processor
- document installing Python dependencies outside docker

## Testing
- `python -m py_compile poc/backend/app/*.py poc/frame-processor/app/*.py`
- `python poc/backend/app/main.py`
- `python poc/frame-processor/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6855f1173268832798e2dfbd94a5c531